### PR TITLE
Remove nilpotent expressions

### DIFF
--- a/src/transpose.cpp
+++ b/src/transpose.cpp
@@ -769,7 +769,7 @@ void fast_transpose_v_hi(T_Plan<T>* T_plan, T * data, double *timings,int kway, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
 #ifdef VERBOSE2
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -1007,7 +1007,7 @@ void fast_transpose_vi(T_Plan<T>* T_plan, T * data, double *timings,int kway, un
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
 #ifdef VERBOSE2
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -1232,7 +1232,7 @@ void fast_transpose_v(T_Plan<T>* T_plan, T * data, double *timings, int kway, un
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
 #ifdef VERBOSE2
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -1484,7 +1484,7 @@ void fast_transpose_v_h(T_Plan<T>* T_plan, T * data, double *timings,int kway, u
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
 #ifdef VERBOSE2
@@ -1768,7 +1768,7 @@ void fast_transpose_v1(T_Plan<T>* T_plan, T * data, double *timings, unsigned fl
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2)
@@ -1991,7 +1991,7 @@ void fast_transpose_v2(T_Plan<T>* T_plan, T * data, double *timings, unsigned fl
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2)
@@ -2190,7 +2190,7 @@ void fast_transpose_v3(T_Plan<T>* T_plan, T * data, double *timings, int kway, u
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2)
@@ -2387,7 +2387,7 @@ void fast_transpose_v1_h(T_Plan<T>* T_plan, T * data, double *timings, unsigned 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -2637,7 +2637,7 @@ void fast_transpose_v2_h(T_Plan<T>* T_plan, T * data, double *timings, unsigned 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -2872,7 +2872,7 @@ void fast_transpose_v3_h(T_Plan<T>* T_plan, T * data, double *timings,int kway, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -3094,7 +3094,7 @@ void transpose_v5(T_Plan<T>* T_plan, T * data, double *timings, unsigned flags, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2)
@@ -3335,7 +3335,7 @@ void transpose_v6(T_Plan<T>* T_plan, T * data, double *timings, unsigned flags, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2)
@@ -3550,7 +3550,7 @@ void transpose_v7(T_Plan<T>* T_plan, T * data, double *timings,int kway, unsigne
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2)
@@ -3728,7 +3728,7 @@ void transpose_v8(T_Plan<T>* T_plan, T * data, double *timings, unsigned flags, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2)

--- a/src/transpose_gpu.cpp
+++ b/src/transpose_gpu.cpp
@@ -5660,8 +5660,7 @@ void transpose_cuda_v6(T_Plan_gpu<T>* T_plan, T * data, double *timings, unsigne
   if(VERBOSE>=2){
     cudaMemcpy(data_cpu, data, T_plan->alloc_local, cudaMemcpyDeviceToHost);
     for(int h=0;h<howmany;h++)
-      for(int id=0;id<1;++id){
-        if(procid==id)
+        if(procid==0)
           for(int i=0;i<local_n0;i++){
             std::cout<<std::endl;
             for(int j=0;j<N[1];j++){
@@ -5670,7 +5669,6 @@ void transpose_cuda_v6(T_Plan_gpu<T>* T_plan, T * data, double *timings, unsigne
           }
         std::cout<<'\n';
         MPI_Barrier(T_plan->comm);
-      }
   }
   //PCOUT<<" ============================================= "<<std::endl;
   //PCOUT<<" ==============   Local Transpose============= "<<std::endl;

--- a/src/transpose_gpu.cpp
+++ b/src/transpose_gpu.cpp
@@ -5660,7 +5660,7 @@ void transpose_cuda_v6(T_Plan_gpu<T>* T_plan, T * data, double *timings, unsigne
   if(VERBOSE>=2){
     cudaMemcpy(data_cpu, data, T_plan->alloc_local, cudaMemcpyDeviceToHost);
     for(int h=0;h<howmany;h++)
-      for(int id=0;id<1+0*nprocs;++id){
+      for(int id=0;id<1;++id){
         if(procid==id)
           for(int i=0;i<local_n0;i++){
             std::cout<<std::endl;

--- a/src/transpose_gpu.cpp
+++ b/src/transpose_gpu.cpp
@@ -790,7 +790,7 @@ void fast_transpose_cuda_v_hi(T_Plan_gpu<T>* T_plan, T * data, double *timings, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
 #ifdef VERBOSE2
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -1140,7 +1140,7 @@ void fast_transpose_cuda_v_i(T_Plan_gpu<T>* T_plan, T * data, double *timings, i
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
 #ifdef VERBOSE2
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -1489,7 +1489,7 @@ void fast_transpose_cuda_v(T_Plan_gpu<T>* T_plan, T * data, double *timings, int
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -1833,7 +1833,7 @@ void fast_transpose_cuda_v_h(T_Plan_gpu<T>* T_plan, T * data, double *timings, i
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -2198,7 +2198,7 @@ void fast_transpose_cuda_v1_h(T_Plan_gpu<T>* T_plan, T * data, double *timings, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -2491,7 +2491,7 @@ void fast_transpose_cuda_v1_2_h(T_Plan_gpu<T>* T_plan, T * data, double *timings
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -2801,7 +2801,7 @@ void fast_transpose_cuda_v1_3_h(T_Plan_gpu<T>* T_plan,T * data, double *timings,
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -3078,7 +3078,7 @@ void fast_transpose_cuda_v1(T_Plan_gpu<T>* T_plan, T * data, double *timings, un
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -3309,7 +3309,7 @@ void fast_transpose_cuda_v1_2(T_Plan_gpu<T>* T_plan, T * data, double *timings, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -3566,7 +3566,7 @@ void fast_transpose_cuda_v1_3(T_Plan_gpu<T>* T_plan, T * data, double *timings, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -3808,7 +3808,7 @@ void fast_transpose_cuda_v2(T_Plan_gpu<T>* T_plan, T * data, double *timings, un
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -4025,7 +4025,7 @@ void fast_transpose_cuda_v3(T_Plan_gpu<T>* T_plan, T * data, double *timings,int
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -4244,7 +4244,7 @@ void fast_transpose_cuda_v3_2(T_Plan_gpu<T>* T_plan, T * data, double *timings,i
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -4459,7 +4459,7 @@ void fast_transpose_cuda_v2_h(T_Plan_gpu<T>* T_plan, T * data, double *timings, 
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -4723,7 +4723,7 @@ void fast_transpose_cuda_v3_h(T_Plan_gpu<T>* T_plan, T * data, double *timings,i
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   int ptr=0;
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
@@ -4982,7 +4982,7 @@ void transpose_cuda_v5(T_Plan_gpu<T>* T_plan, T * data, double *timings, unsigne
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -5206,7 +5206,7 @@ void transpose_cuda_v5_2(T_Plan_gpu<T>* T_plan, T* data, double *timings, unsign
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -5441,7 +5441,7 @@ void transpose_cuda_v5_3(T_Plan_gpu<T>* T_plan, T * data, double *timings, unsig
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -5654,7 +5654,7 @@ void transpose_cuda_v6(T_Plan_gpu<T>* T_plan, T * data, double *timings, unsigne
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -5855,7 +5855,7 @@ void transpose_cuda_v7(T_Plan_gpu<T>* T_plan, T * data, double *timings,int kway
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){
@@ -6053,7 +6053,7 @@ void transpose_cuda_v7_2(T_Plan_gpu<T>* T_plan, T * data, double *timings,int kw
   int idist=N[1]*local_n0*n_tuples;
   int odist=N[0]*local_n1*n_tuples;
 
-  double comm_time=0*MPI_Wtime(), shuffle_time=0*MPI_Wtime(), reshuffle_time=0*MPI_Wtime(), total_time=0*MPI_Wtime();
+  double comm_time=0, shuffle_time=0, reshuffle_time=0, total_time=0;
 
   if(VERBOSE>=2) PCOUT<<"INPUT:"<<std::endl;
   if(VERBOSE>=2){


### PR DESCRIPTION
I removed three sets of `0*something` expressions.

In one case, this rendered a loop trivial (trip count of 1, with index of 0), so I removed it.

As with #5, I have not tested these changes.