### PR TITLE
Fixed linking of step* executables when producing shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ if(BUILD_SHARED_LIBS)
 else(BUILD_SHARED_LIBS)
   add_library(accfft STATIC ${libaccfft_SRCS})
 endif(BUILD_SHARED_LIBS)
+target_link_libraries(accfft ${FFTW_LIB} ${FFTWF_LIB})
 
 # install
 install(TARGETS accfft DESTINATION lib)
@@ -110,6 +111,8 @@ if(BUILD_SHARED_LIBS)
 else(BUILD_SHARED_LIBS)
   add_library(accfft_utils STATIC ${libaccfft_utils_SRCS})
 endif(BUILD_SHARED_LIBS)
+
+target_link_libraries(accfft_utils accfft)
 
 install(TARGETS accfft_utils DESTINATION lib)
 


### PR DESCRIPTION
Before this commit the library was not able to link the `step*` executables when configuring the build to produce shared libraries (undefined references to a few symbols). 

The command used to configure cmake is:
```console
/home/mculpo/wdir/spack/opt/spack/linux-ubuntu14.04-x86_64/gcc-7.2.0/cmake-3.10.1-jesjiohtkv5xkvk7pzclz44deokswwat/bin/cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/home/mculpo/wdir/spack/opt/spack/linux-ubuntu14.04-x86_64/gcc-4.8/gcc-7.2.0-xcl3ci5etaxopfb4fuiesepfbtrfwthh/bin/gcc -DCMAKE_CXX_COMPILER=/home/mculpo/wdir/spack/opt/spack/linux-ubuntu14.04-x86_64/gcc-4.8/gcc-7.2.0-xcl3ci5etaxopfb4fuiesepfbtrfwthh/bin/g++ -DBUILD_SHARED=true -G "CodeBlocks - Unix Makefiles" /home/mculpo/jetbrains/CLionProjects/accfft
```
and, before this PR, it fails with:
```console
<lot of output omitted>
[ 92%] Linking CXX executable step1
../../libaccfft.so: undefined reference to `fftwf_execute_dft_r2c'
../../libaccfft.so: undefined reference to `fftwf_plan_many_dft_r2c'
../../libaccfft.so: undefined reference to `fftwf_execute_dft'
../../libaccfft.so: undefined reference to `fftwf_plan_many_dft'
../../libaccfft.so: undefined reference to `fftwf_plan_many_dft_c2r'
../../libaccfft.so: undefined reference to `fftwf_execute_dft_c2r'
../../libaccfft.so: undefined reference to `fftwf_destroy_plan'
../../libaccfft.so: undefined reference to `fftwf_plan_guru_dft'
collect2: error: ld returned 1 exit status
make[3]: *** [steps/step1/step1] Error 1
make[2]: *** [steps/step1/CMakeFiles/step1.dir/all] Error 2
make[1]: *** [steps/step1/CMakeFiles/step1.dir/rule] Error 2
make: *** [step1] Error 2
```