### PR TITLE
Fix odr violation on GPUs + don't override user nvcc flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,12 +121,15 @@ install(TARGETS accfft_utils DESTINATION lib)
 # ##########
 if(BUILD_GPU)
   find_package(CUDA REQUIRED)
-  include(FindCUDA)
+
+  if(NOT CUDA_NVCC_FLAGS)
+    list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_20,code=sm_20)
+    list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_30,code=sm_30)
+    list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_35,code=sm_35)
+  endif()
+
   list(APPEND CUDA_NVCC_FLAGS --compiler-options -fno-strict-aliasing -lineinfo)
-  list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_20,code=sm_20)
-  list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_30,code=sm_30)
-  list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_35,code=sm_35)
-  
+
   # libaccfft_gpu source files list
   set(libaccfft_gpu_SRCS
     src/transpose_gpu.cpp

--- a/src/operators_gpu.cpp
+++ b/src/operators_gpu.cpp
@@ -24,6 +24,31 @@
 #include <accfft_gpu.h>
 #include "operators_gpu.txx"
 
+/* Double Precision Instantiation */
+template<> void grad_mult_wave_numberx_gpu<Complex>(Complex* wA, Complex* A,
+                                                    int* N, int * osize, int * ostart, std::bitset<3> xyz) {
+    grad_mult_wave_numberx_gpu_c(wA, A, N, osize, ostart, xyz);
+}
+template<> void grad_mult_wave_numbery_gpu<Complex>(Complex* wA, Complex* A,
+                                                    int* N, int * osize, int * ostart, std::bitset<3> xyz) {
+    grad_mult_wave_numbery_gpu_c(wA, A, N, osize, ostart, xyz);
+}
+template<> void grad_mult_wave_numberz_gpu<Complex>(Complex* wA, Complex* A,
+                                                    int* N, int * osize, int * ostart, std::bitset<3> xyz) {
+    grad_mult_wave_numberz_gpu_c(wA, A, N, osize, ostart, xyz);
+}
+template<> void laplace_mult_wave_number_gpu<Complex>(Complex* wA, Complex* A,
+                                                      int* N, int * osize, int * ostart) {
+    laplace_mult_wave_number_gpu_c(wA, A, N, osize, ostart);
+}
+template<> void biharmonic_mult_wave_number_gpu<Complex>(Complex* wA,
+                                                         Complex* A, int* N, int * osize, int * ostart) {
+    biharmonic_mult_wave_number_gpu_c(wA, A, N, osize, ostart);
+}
+template<> void daxpy_gpu<double>(const long long int n, const double alpha,
+                                  double* x, double* y) {
+    daxpy_gpu_c(n, alpha, x, y);
+}
 
 /* Double Precision Instantiation */
 template void accfft_grad_gpu_slow_t<double, accfft_plan_gpu>(double * A_x,

--- a/src/operators_gpu.txx
+++ b/src/operators_gpu.txx
@@ -68,57 +68,6 @@ void biharmonic_mult_wave_number_gpu_cf(Complexf* wA, Complexf* A, int*n,
 void daxpy_gpu_cf(const long long int n, const float alpha, float *x, float* y);
 }
 
-/* Double Precision Instantiation */
-template<> void grad_mult_wave_numberx_gpu<Complex>(Complex* wA, Complex* A,
-		int* N, int * osize, int * ostart, std::bitset<3> xyz) {
-	grad_mult_wave_numberx_gpu_c(wA, A, N, osize, ostart, xyz);
-}
-template<> void grad_mult_wave_numbery_gpu<Complex>(Complex* wA, Complex* A,
-		int* N, int * osize, int * ostart, std::bitset<3> xyz) {
-	grad_mult_wave_numbery_gpu_c(wA, A, N, osize, ostart, xyz);
-}
-template<> void grad_mult_wave_numberz_gpu<Complex>(Complex* wA, Complex* A,
-		int* N, int * osize, int * ostart, std::bitset<3> xyz) {
-	grad_mult_wave_numberz_gpu_c(wA, A, N, osize, ostart, xyz);
-}
-template<> void laplace_mult_wave_number_gpu<Complex>(Complex* wA, Complex* A,
-		int* N, int * osize, int * ostart) {
-	laplace_mult_wave_number_gpu_c(wA, A, N, osize, ostart);
-}
-template<> void biharmonic_mult_wave_number_gpu<Complex>(Complex* wA,
-		Complex* A, int* N, int * osize, int * ostart) {
-	biharmonic_mult_wave_number_gpu_c(wA, A, N, osize, ostart);
-}
-template<> void daxpy_gpu<double>(const long long int n, const double alpha,
-		double* x, double* y) {
-	daxpy_gpu_c(n, alpha, x, y);
-}
-
-/* Single Precision Instantiation */
-template<> void grad_mult_wave_numberx_gpu<Complexf>(Complexf* wA, Complexf* A,
-		int* N, int * osize, int * ostart, std::bitset<3> xyz) {
-	grad_mult_wave_numberx_gpu_cf(wA, A, N, osize, ostart, xyz);
-}
-template<> void grad_mult_wave_numbery_gpu<Complexf>(Complexf* wA, Complexf* A,
-		int* N, int * osize, int * ostart, std::bitset<3> xyz) {
-	grad_mult_wave_numbery_gpu_cf(wA, A, N, osize, ostart, xyz);
-}
-template<> void grad_mult_wave_numberz_gpu<Complexf>(Complexf* wA, Complexf* A,
-		int* N, int * osize, int * ostart, std::bitset<3> xyz) {
-	grad_mult_wave_numberz_gpu_cf(wA, A, N, osize, ostart, xyz);
-}
-template<> void laplace_mult_wave_number_gpu<Complexf>(Complexf* wA,
-		Complexf* A, int* N, int * osize, int * ostart) {
-	laplace_mult_wave_number_gpu_cf(wA, A, N, osize, ostart);
-}
-template<> void biharmonic_mult_wave_number_gpu<Complexf>(Complexf* wA,
-		Complexf* A, int* N, int * osize, int * ostart) {
-	biharmonic_mult_wave_number_gpu_cf(wA, A, N, osize, ostart);
-}
-template<> void daxpy_gpu<float>(const long long int n, const float alpha,
-		float* x, float* y) {
-	daxpy_gpu_cf(n, alpha, x, y);
-}
 
 template<typename T, typename Tp>
 void accfft_grad_gpu_slow_t(T* A_x, T* A_y, T*A_z, T* A, Tp* plan,

--- a/src/operators_gpuf.cpp
+++ b/src/operators_gpuf.cpp
@@ -33,6 +33,32 @@
 #include "operators_gpu.txx"
 
 /* Single Precision Instantiation */
+template<> void grad_mult_wave_numberx_gpu<Complexf>(Complexf* wA, Complexf* A,
+                                                     int* N, int * osize, int * ostart, std::bitset<3> xyz) {
+    grad_mult_wave_numberx_gpu_cf(wA, A, N, osize, ostart, xyz);
+}
+template<> void grad_mult_wave_numbery_gpu<Complexf>(Complexf* wA, Complexf* A,
+                                                     int* N, int * osize, int * ostart, std::bitset<3> xyz) {
+    grad_mult_wave_numbery_gpu_cf(wA, A, N, osize, ostart, xyz);
+}
+template<> void grad_mult_wave_numberz_gpu<Complexf>(Complexf* wA, Complexf* A,
+                                                     int* N, int * osize, int * ostart, std::bitset<3> xyz) {
+    grad_mult_wave_numberz_gpu_cf(wA, A, N, osize, ostart, xyz);
+}
+template<> void laplace_mult_wave_number_gpu<Complexf>(Complexf* wA,
+                                                       Complexf* A, int* N, int * osize, int * ostart) {
+    laplace_mult_wave_number_gpu_cf(wA, A, N, osize, ostart);
+}
+template<> void biharmonic_mult_wave_number_gpu<Complexf>(Complexf* wA,
+                                                          Complexf* A, int* N, int * osize, int * ostart) {
+    biharmonic_mult_wave_number_gpu_cf(wA, A, N, osize, ostart);
+}
+template<> void daxpy_gpu<float>(const long long int n, const float alpha,
+                                 float* x, float* y) {
+    daxpy_gpu_cf(n, alpha, x, y);
+}
+
+/* Single Precision Instantiation */
 template void accfft_grad_gpu_t<float, accfft_plan_gpuf>(float* A_x, float* A_y,
 		float *A_z, float* A, accfft_plan_gpuf *plan, std::bitset<3> *pXYZ,
 		double* timer);


### PR DESCRIPTION
Currently, when building for GPUs, one may encounter two errors. The first one is that on newer machines you may have unsupported architectures:
```console
 nvcc fatal   : Unsupported gpu architecture 'compute_20'
```
This is due to the unconditional defaults that are applied by the current `CMakeLists.txt`.

The second one is an odr violation when linking `accfft_utils_gpu`:
```console
...
     150    CMakeFiles/accfft_utils_gpu.dir/src/operators_gpuf.cpp.o: In function `void grad_mult_wave_numberx_gpu<double [2]>(double (*) [2], double (*) [2], int*, int*, int*, std::bitset<3ul>)':
  >> 151    /home/culpo/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/openmpi-3.0.0-hbngn7435u72u4ooh3bkgesx2t4bgw6v/include/openmpi/ompi/mpi/cxx/topology_inln.h:105: multiple definition of `void grad_mult_wav
            e_numberx_gpu<double [2]>(double (*) [2], double (*) [2], int*, int*, int*, std::bitset<3ul>)'
  >> 152    CMakeFiles/accfft_utils_gpu.dir/src/operators_gpu.cpp.o:/home/culpo/spack/opt/spack/linux-centos7-x86_64/gcc-4.8.5/openmpi-3.0.0-hbngn7435u72u4ooh3bkgesx2t4bgw6v/include/openmpi/ompi/mpi/cxx/topolog
            y_inln.h:105: first defined here
...
```
due to the fact that we instantiate templates in an header file that is included at multiple locations. 

This PR solves both issues, see commit comments for more info.